### PR TITLE
Add support for defining relative positions of entries on the X axis

### DIFF
--- a/library/src/com/db/chart/model/ChartEntry.java
+++ b/library/src/com/db/chart/model/ChartEntry.java
@@ -25,6 +25,7 @@ public class ChartEntry {
 	/** Input from user */
 	private String mLabel;
 	private float mValue;
+	private int xIndex = -1;
 
 	
 	/** Display coordinates */
@@ -39,7 +40,11 @@ public class ChartEntry {
 		mValue = value;
 	}
 
-	
+	public ChartEntry(String label, float value, int xIndex){
+		mLabel = label;
+		mValue = value;
+		this.xIndex = xIndex;
+	}
 	
 	
 	/*
@@ -58,7 +63,16 @@ public class ChartEntry {
 		return mValue;
 	}
 
-	
+
+	public int getxIndex() {
+		return xIndex;
+	}
+
+	public void setxIndex(int xIndex) {
+		this.xIndex = xIndex;
+	}
+
+
 	public float getX() {
 		return mX;
 	}
@@ -68,7 +82,10 @@ public class ChartEntry {
 		return mY;
 	}
 
-	
+
+	public boolean hasXIndex(){
+		return (xIndex != -1);
+	}
 
 	
 	/*

--- a/library/src/com/db/chart/model/ChartSet.java
+++ b/library/src/com/db/chart/model/ChartSet.java
@@ -42,10 +42,14 @@ public class ChartSet {
 		mAlpha = 1;
 		mIsVisible = false;
 	}
-	
-	
-	
-	
+
+
+
+	protected void addEntry(String label, float value, int xIndex){
+		mEntries.add(new ChartEntry(label, value, xIndex));
+	}
+
+
 	protected void addEntry(String label, float value){
 		mEntries.add(new ChartEntry(label, value));
 	}
@@ -74,8 +78,23 @@ public class ChartSet {
 		}
 		return result;
 	}
-	
-	
+
+	/**
+	 * Updates set values.
+	 * @param newValues
+	 * @param xIndices
+	 * @return float[] with X and Y coordinates of old values
+	 */
+	public float[][] updateValues(float[] newValues, int[] xIndices){
+
+		float[][] result = new float[size()][2];
+		for(int i = 0; i < size(); i++){
+			result[i][0] = getEntry(i).getX();
+			result[i][1] = getEntry(i).getY();
+			setValue(i, newValues[i], xIndices[i]);
+		}
+		return result;
+	}
 	
 	
 	/*
@@ -165,6 +184,16 @@ public class ChartSet {
 	 */
 	private void setValue(int i, float value){
 		mEntries.get(i).setValue(value);
+	}
+
+	/**
+	 * Set {@link ChartEntry} value at specific index position.
+	 * @param i - value's index where value will be placed.
+	 * @param xIndex - x index (position on x axis)
+	 */
+	private void setValue(int i, float value, int xIndex){
+		mEntries.get(i).setValue(value);
+		mEntries.get(i).setxIndex(xIndex);
 	}
 	
 	

--- a/library/src/com/db/chart/model/ChartSet.java
+++ b/library/src/com/db/chart/model/ChartSet.java
@@ -82,7 +82,7 @@ public class ChartSet {
 	/**
 	 * Updates set values.
 	 * @param newValues
-	 * @param xIndices
+	 * @param xIndices - relative positions of entries on the X axis
 	 * @return float[] with X and Y coordinates of old values
 	 */
 	public float[][] updateValues(float[] newValues, int[] xIndices){
@@ -189,7 +189,7 @@ public class ChartSet {
 	/**
 	 * Set {@link ChartEntry} value at specific index position.
 	 * @param i - value's index where value will be placed.
-	 * @param xIndex - x index (position on x axis)
+	 * @param xIndex - x index (relative position on x axis)
 	 */
 	private void setValue(int i, float value, int xIndex){
 		mEntries.get(i).setValue(value);

--- a/library/src/com/db/chart/model/LineSet.java
+++ b/library/src/com/db/chart/model/LineSet.java
@@ -118,8 +118,12 @@ public class LineSet extends ChartSet{
 	public void addPoint(String label, float value){
 		this.addPoint(new Point(label, value));
 	}
-	
-	
+
+	public void addPoint(String label, float value, int xIndex){
+		this.addPoint(new Point(label, value, xIndex));
+	}
+
+
 	public void addPoint(Point point){
 		this.addEntry(point);
 	}
@@ -134,9 +138,19 @@ public class LineSet extends ChartSet{
 		for(int i = 0; i < nEntries; i++)
 			addPoint(labels[i], values[i]);
 	}
-	
-	
-	
+
+	public void addPoints(String[] labels, float[] values, int[] xIndices){
+
+		if(labels.length != values.length)
+			Log.e(TAG, "Arrays size doesn't match.", new IllegalArgumentException());
+
+		int nEntries = labels.length;
+		for(int i = 0; i < nEntries; i++)
+			addPoint(labels[i], values[i], xIndices[i]);
+	}
+
+
+
 	public boolean hasDots() {
 		return mHasDots;
 	}

--- a/library/src/com/db/chart/model/Point.java
+++ b/library/src/com/db/chart/model/Point.java
@@ -24,5 +24,9 @@ public class Point extends ChartEntry{
 	public Point(String label, float value){
 		super(label, value);
 	}
-	
+
+
+	public Point(String label, float value, int xIndex){
+		super(label, value, xIndex);
+	}
 }

--- a/library/src/com/db/chart/view/ChartView.java
+++ b/library/src/com/db/chart/view/ChartView.java
@@ -431,6 +431,7 @@ public abstract class ChartView extends RelativeLayout{
 	 * Update set values. Animation support in case previously added.
 	 * @param setIndex - Index of set to be updated
 	 * @param values - Array of new values. Array length must match current data.
+	 * @param xIndices - Array of relative positions of entries on the X axis
 	 */
 	public ChartView updateValues(int setIndex, float[] values, int[] xIndices){
 

--- a/library/src/com/db/chart/view/ChartView.java
+++ b/library/src/com/db/chart/view/ChartView.java
@@ -426,7 +426,20 @@ public abstract class ChartView extends RelativeLayout{
 		data.get(setIndex).updateValues(values);
 		return this;
 	}
-	
+
+	/**
+	 * Update set values. Animation support in case previously added.
+	 * @param setIndex - Index of set to be updated
+	 * @param values - Array of new values. Array length must match current data.
+	 */
+	public ChartView updateValues(int setIndex, float[] values, int[] xIndices){
+
+		if(values.length != data.get(setIndex).size())
+			Log.e(TAG, "New values size doesn't match current dataset size.", new IllegalArgumentException());
+
+		data.get(setIndex).updateValues(values, xIndices);
+		return this;
+	}
 	
 	/**
 	 * Notify ChartView about updated values. ChartView will be validated.

--- a/library/src/com/db/chart/view/XController.java
+++ b/library/src/com/db/chart/view/XController.java
@@ -152,28 +152,62 @@ public class XController{
 
 	/**
 	 * Get labels position having into account the horizontal padding of text size.
-	 * @param nLabels- number of labels to display
 	 */
 	private ArrayList<Float> calcLabelsPos() {
 		
 		ArrayList<Float> result = new ArrayList<Float>(nEntries);
+
+		// last entry contains the highest index
+		ChartEntry lastEntry =  mChartView.data.get(0).getEntry(mChartView.data.get(0).getEntries().size()-1);
 		
 		if(nEntries == 1)
 			result.add(mChartView.getInnerChartLeft() + (getInnerChartRight() - mChartView.getInnerChartLeft())/2);
 		else{
-			final float screenStep = 
-					(getInnerChartRight()
-						- mChartView.getInnerChartLeft() 
-						- mChartView.style.axisThickness/2
-						//if 0 first label will be right at the beginning of the axis
-						- borderSpacing * 2
-						- mandatoryBorderSpacing * 2 ) 
-					/ (nEntries - 1);
+			if(lastEntry.hasXIndex()) {
 
-			float pos = mChartView.getInnerChartLeft() + borderSpacing + mandatoryBorderSpacing;
-			while(pos <= mChartView.chartRight - borderSpacing - mandatoryBorderSpacing){
-				result.add(pos);
-				pos += screenStep;
+				ArrayList<ChartEntry> entries = mChartView.data.get(0).getEntries();
+
+				int highestXIndex = lastEntry.getxIndex();
+
+				final float screenStep =
+						(getInnerChartRight()
+								- mChartView.getInnerChartLeft()
+								- mChartView.style.axisThickness / 2
+								//if 0 first label will be right at the beginning of the axis
+								- borderSpacing * 2
+								- mandatoryBorderSpacing * 2)
+								/// (nLabels-1);
+								/ (highestXIndex);
+
+				float pos = mChartView.getInnerChartLeft() + borderSpacing + mandatoryBorderSpacing;
+				int xIndexPos = 0;
+				int count = 0;
+				while (pos <= (mChartView.chartRight - borderSpacing - mandatoryBorderSpacing)
+						&& count <= highestXIndex) {
+
+					if (entries.get(xIndexPos).getxIndex() == count) {
+						result.add(pos);
+						xIndexPos++;
+					}
+					pos += screenStep;
+					count++;
+				}
+
+			} else {
+				final float screenStep =
+						(getInnerChartRight()
+								- mChartView.getInnerChartLeft()
+								- mChartView.style.axisThickness / 2
+								//if 0 first label will be right at the beginning of the axis
+								- borderSpacing * 2
+								- mandatoryBorderSpacing * 2)
+								/ (nEntries - 1);
+
+				float pos = mChartView.getInnerChartLeft() + borderSpacing + mandatoryBorderSpacing;
+				while (pos <= mChartView.chartRight - borderSpacing - mandatoryBorderSpacing) {
+					result.add(pos);
+					pos += screenStep;
+				}
 			}
 		}
 		

--- a/library/src/com/db/chart/view/XController.java
+++ b/library/src/com/db/chart/view/XController.java
@@ -163,6 +163,8 @@ public class XController{
 		if(nEntries == 1)
 			result.add(mChartView.getInnerChartLeft() + (getInnerChartRight() - mChartView.getInnerChartLeft())/2);
 		else{
+
+			// maybe not the best way to check if an entry has an xIndex..
 			if(lastEntry.hasXIndex()) {
 
 				ArrayList<ChartEntry> entries = mChartView.data.get(0).getEntries();

--- a/sample/src/com/db/chartviewdemo/MainActivity.java
+++ b/sample/src/com/db/chartviewdemo/MainActivity.java
@@ -132,7 +132,8 @@ public class MainActivity extends ActionBarActivity {
 	private final static int LINE_MAX = 10;
 	private final static int LINE_MIN = -10;
 	private final static String[] lineLabels = {"", "ANT", "GNU", "OWL", "APE", "JAY", ""};
-	private final static float[][] lineValues = { {-5f, 6f, 2f, 9f, 0f, -2f, 5f}, 
+	private final static int[] xIndices = {0, 1, 4, 5, 6, 11, 13};
+	private final static float[][] lineValues = { {-5f, 6f, 2f, 9f, 0f, -2f, 5f},
 													{-9f, -2f, -4f, -3f, -7f, -5f, -3f}};
 	private static LineChartView mLineChart;
 	private Paint mLineGridPaint;
@@ -285,7 +286,7 @@ public class MainActivity extends ActionBarActivity {
 		mLineChart.reset();
 		
 		LineSet dataSet = new LineSet();
-		dataSet.addPoints(lineLabels, lineValues[0]);
+		dataSet.addPoints(lineLabels, lineValues[0], xIndices);
 		dataSet.setDots(true)
 			.setDotsColor(this.getResources().getColor(R.color.line_bg))
 			.setDotsRadius(Tools.fromDpToPx(5))
@@ -297,7 +298,7 @@ public class MainActivity extends ActionBarActivity {
 		mLineChart.addData(dataSet);
 		
 		dataSet = new LineSet();
-		dataSet.addPoints(lineLabels, lineValues[1]);
+		dataSet.addPoints(lineLabels, lineValues[1], xIndices);
 		dataSet.setLineColor(this.getResources().getColor(R.color.line))
 			.setLineThickness(Tools.fromDpToPx(3))
 			.setSmooth(true)
@@ -377,8 +378,8 @@ public class MainActivity extends ActionBarActivity {
 	
 	private void updateValues(LineChartView chartView){
 		
-		chartView.updateValues(0, lineValues[1]);
-		chartView.updateValues(1, lineValues[0]);
+		chartView.updateValues(0, lineValues[1], xIndices);
+		chartView.updateValues(1, lineValues[0], xIndices);
 		chartView.notifyDataUpdate();
 	}
 	

--- a/sample/src/com/db/chartviewdemo/MainActivity.java
+++ b/sample/src/com/db/chartviewdemo/MainActivity.java
@@ -286,6 +286,7 @@ public class MainActivity extends ActionBarActivity {
 		mLineChart.reset();
 		
 		LineSet dataSet = new LineSet();
+		// xIndex parameter is optional
 		dataSet.addPoints(lineLabels, lineValues[0], xIndices);
 		dataSet.setDots(true)
 			.setDotsColor(this.getResources().getColor(R.color.line_bg))
@@ -379,7 +380,9 @@ public class MainActivity extends ActionBarActivity {
 	private void updateValues(LineChartView chartView){
 		
 		chartView.updateValues(0, lineValues[1], xIndices);
+		//chartView.updateValues(0, lineValues[1]);
 		chartView.updateValues(1, lineValues[0], xIndices);
+		//chartView.updateValues(1, lineValues[0]);
 		chartView.notifyDataUpdate();
 	}
 	


### PR DESCRIPTION
You can define position of an entry on the X axis, if you don't want them to be equidistant. For example:

values = [10f, 10f, 13f, 17f, 15f, 9f, 9f]
labels = ["", "01.02.2014", "02.02.2014", "06.02.2014", "07.02.2014", "08.02.2014", ""]

This fix allows them to display the values based on the relative distance between them. Just define their positions xIndex like below:

xIndices = [0, 1, 2, 6, 7, 8, 9]

And the spacing of the values changes based on the position given.
![device-2015-01-29-220030](https://cloud.githubusercontent.com/assets/2365058/5966213/b9f265d0-a802-11e4-93b9-019f90224406.png)

This fixes #31 ?