### PR TITLE
Corrected example XML definition of LineChartView and BarChartView.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ LineChart
 ----------
 
 ```xml
-    <com.db.chart.LineChartView
+    <com.db.chart.view.LineChartView
         ... 
     />
 ```
@@ -177,7 +177,7 @@ LineChart
 -------------------------
 
 ```xml
-    <com.db.chart.BarChartView
+    <com.db.chart.view.BarChartView
         ... 
         chart:chart_barSpacing="dp"
         chart:chart_setSpacing="dp"


### PR DESCRIPTION
Unless I've overlooked something, com.db.chart.LineChartView is an incorrect notation and results in Android Studio unable to find the class. Seems like the correct definition is com.db.chart.view.LineChartView.