### PR TITLE
remove static reference in sample project

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ GROUP=com.diogobernardino
 ANDROID_BUILD_MIN_SDK_VERSION=8
 ANDROID_BUILD_TARGET_SDK_VERSION=23
 ANDROID_BUILD_SDK_VERSION=23
-ANDROID_BUILD_TOOLS_VERSION=23.0.0
+ANDROID_BUILD_TOOLS_VERSION=23.0.1
 
 POM_DESCRIPTION=Flexible charting library with nice motion effects.
 POM_URL=https://github.com/diogobernardino/WilliamChart

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'com.android.application'
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:23.0.0'
-    compile 'com.android.support:design:23.0.0'
-    compile 'com.android.support:cardview-v7:23.0.0'
+    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:design:23.0.1'
+    compile 'com.android.support:cardview-v7:23.0.1'
     compile 'com.larswerkman:HoloColorPicker:1.5'
     testCompile 'junit:junit:4.12'
 }

--- a/sample/src/com/db/williamchartdemo/SandboxFragment.java
+++ b/sample/src/com/db/williamchartdemo/SandboxFragment.java
@@ -578,7 +578,7 @@ public class SandboxFragment extends Fragment {
 
 
 
-    public class SandboxPagerAdapter extends FragmentStatePagerAdapter {
+    public static class SandboxPagerAdapter extends FragmentStatePagerAdapter {
 
         public SandboxPagerAdapter(FragmentManager fm) {
             super(fm);
@@ -686,8 +686,8 @@ public class SandboxFragment extends Fragment {
 
     public static class SandBoxChartFragment extends BaseSandBoxFragment {
 
-        private static View mLayout;
-        private static AlertDialog.Builder mDialogBuilder;
+        private  View mLayout;
+        private  AlertDialog.Builder mDialogBuilder;
 
 
         @Override
@@ -714,9 +714,9 @@ public class SandboxFragment extends Fragment {
 
     public static class SandBoxAxisFragment extends BaseSandBoxFragment {
 
-        private static View mLayout;
-        private static ViewGroup mViewGroup;
-        private static AlertDialog.Builder mDialogBuilder;
+        private  View mLayout;
+        private  ViewGroup mViewGroup;
+        private  AlertDialog.Builder mDialogBuilder;
 
 
         @Override
@@ -854,9 +854,9 @@ public class SandboxFragment extends Fragment {
 
     public static class SandBoxGridFragment extends BaseSandBoxFragment {
 
-        private static View mLayout;
-        private static ViewGroup mViewGroup;
-        private static AlertDialog.Builder mDialogBuilder;
+        private  View mLayout;
+        private  ViewGroup mViewGroup;
+        private  AlertDialog.Builder mDialogBuilder;
 
 
         @Override
@@ -963,9 +963,9 @@ public class SandboxFragment extends Fragment {
 
     public static class SandBoxLineFragment extends BaseSandBoxFragment {
 
-        private static View mLayout;
-        private static ViewGroup mViewGroup;
-        private static AlertDialog.Builder mDialogBuilder;
+        private  View mLayout;
+        private  ViewGroup mViewGroup;
+        private  AlertDialog.Builder mDialogBuilder;
 
 
         @Override
@@ -1098,9 +1098,9 @@ public class SandboxFragment extends Fragment {
 
     public static class SandBoxBarFragment extends BaseSandBoxFragment {
 
-        private static View mLayout;
-        private static ViewGroup mViewGroup;
-        private static AlertDialog.Builder mDialogBuilder;
+        private  View mLayout;
+        private  ViewGroup mViewGroup;
+        private  AlertDialog.Builder mDialogBuilder;
 
 
         @Override
@@ -1216,7 +1216,7 @@ public class SandboxFragment extends Fragment {
 
     public static class SandBoxAnimationFragment extends BaseSandBoxFragment {
 
-        private static View mLayout;
+        private View mLayout;
 
 
         @Override
@@ -1379,7 +1379,7 @@ public class SandboxFragment extends Fragment {
 
     public static class SandBoxPlayFragment extends BaseSandBoxFragment {
 
-        private static View mLayout;
+        private View mLayout;
 
 
         @Override


### PR DESCRIPTION
Static references to Views (or anything context related) may lead to memory leaks, so I removed the static qualifier.
http://android-developers.blogspot.com.br/2009/01/avoiding-memory-leaks.html