### PR TITLE
Fix for Chart Values <1 and >=0 with ClickListener

### DIFF
--- a/library/src/com/db/chart/view/ChartView.java
+++ b/library/src/com/db/chart/view/ChartView.java
@@ -859,8 +859,8 @@ public abstract class ChartView extends RelativeLayout{
 
 				//Check if ACTION_DOWN over any ScreenPoint region.
 				int nSets = mRegions.size();
-				int nEntries = mRegions.get(0).size();
 				for(int i = 0; i < nSets ; i++){
+					int nEntries = mRegions.get(i).size();
 					for(int j = 0; j < nEntries; j++){
 
 						if(mRegions.get(i).get(j)


### PR DESCRIPTION
Two changes: 1) Move the second loop size inside the first, 2) Use the first loop iteration counter inside the second loop size call
https://github.com/diogobernardino/WilliamChart/issues/110#issuecomment-231404224