### PR TITLE
Added setLabel() function to ChartEntry.java

### DIFF
--- a/williamchart/src/main/java/com/db/chart/model/ChartEntry.java
+++ b/williamchart/src/main/java/com/db/chart/model/ChartEntry.java
@@ -166,6 +166,17 @@ public abstract class ChartEntry implements Comparable<ChartEntry> {
 
 		mValue = value;
 	}
+	
+	
+	/**
+	 * Set new String label.
+	 *
+	 * @param label New label
+	 */
+	public void setLabel(String label) {
+
+		mLabel = label;
+	}
 
 
 	/**


### PR DESCRIPTION
You recommend setting X labels as "" to emulate X axis steps on horizontal steps (#127, #151).

For a bar chart, if more bars are created, there doesn't seem to be a way to go back and reset the labels if I want to display a fixed number of labels at regular intervals.

Example, if there are 30 bars, the labels would be {0, 10, 20, 30}. If a bar at 75 was added, the labels would become {0, 25, 50, 75}.

Adding a setLabel() function allows me to reset the labels after the ChartEntry objects have been created.