### PR TITLE
Added setLabel() to ChartEntry.java

### DIFF
--- a/williamchart/src/main/java/com/db/chart/model/ChartEntry.java
+++ b/williamchart/src/main/java/com/db/chart/model/ChartEntry.java
@@ -30,7 +30,7 @@ public abstract class ChartEntry implements Comparable<ChartEntry> {
 
 
 	/** Input from user */
-	final private String mLabel;
+	private String mLabel;
 
 	/** Defines if entry is visible */
 	boolean isVisible;

--- a/williamchart/src/main/java/com/db/chart/model/ChartEntry.java
+++ b/williamchart/src/main/java/com/db/chart/model/ChartEntry.java
@@ -169,6 +169,17 @@ public abstract class ChartEntry implements Comparable<ChartEntry> {
 
 
 	/**
+	 * Set new String label.
+	 *
+	 * @param label New label
+	 */
+	public void setLabel(String label) {
+
+		mLabel = label;
+	}
+
+
+	/**
 	 * Set the parsed display coordinates.
 	 *
 	 * @param x display x coordinate.


### PR DESCRIPTION
You recommend setting X labels as "" to emulate X axis steps on horizontal steps (#127, #151).

For a bar chart, if more bars are created, there doesn't seem to be a way to go back and reset the labels if I want to display a fixed number of labels at regular intervals.

Example, if there are 30 bars, the visible labels would be {0, 10, 20, 30}. If a bar at 75 was added, the visible labels would become {0, 25, 50, 75}.

Adding a setLabel() function allows me to reset the labels after the ChartEntry objects have been created.
