### PR TITLE
Force 1 sized height to entry regions in all cases

### DIFF
--- a/williamchart/src/main/java/com/db/chart/view/BarChartView.java
+++ b/williamchart/src/main/java/com/db/chart/view/BarChartView.java
@@ -173,11 +173,11 @@ public class BarChartView extends BaseBarChartView {
 				if (bar.getValue() > 0) regions.get(j)
 						  .get(i)
 						  .set((int) offset, (int) bar.getY(), (int) (offset += barWidth),
-									 (int) this.getZeroPosition());
+									 (int) this.getZeroPosition() + ((int) bar.getY() == (int) this.getZeroPosition() ? 1 : 0));
 				else if (bar.getValue() < 0) regions.get(j)
 						  .get(i)
 						  .set((int) offset, (int) this.getZeroPosition(), (int) (offset += barWidth),
-									 (int) bar.getY());
+									 (int) bar.getY() + ((int) bar.getY() == (int) this.getZeroPosition() ? 1 : 0));
 				else regions.get(j)
 							  .get(i)
 							  .set((int) offset, (int) this.getZeroPosition(), (int) (offset += barWidth),


### PR DESCRIPTION
I've updated the define regions for BarChartView to fix that all regions have at least 1 unit height.

This is my first pull request on an open source project, so I hope I haven't done something really wrong 😄 

This fix is referenced to #130  