### PR TITLE
Fix recalculation of axes' labels when redrawing

### DIFF
--- a/williamchart/src/main/java/com/db/williamchart/renderer/BarChartRenderer.kt
+++ b/williamchart/src/main/java/com/db/williamchart/renderer/BarChartRenderer.kt
@@ -36,22 +36,9 @@ class BarChartRenderer(
 
     private lateinit var chartConfiguration: BarChartConfiguration
 
-    private val xLabels: List<Label> by lazy {
-        data.toLabels()
-    }
+    private lateinit var xLabels: List<Label>
 
-    private val yLabels by lazy {
-        val scaleStep = chartConfiguration.scale.size / RendererConstants.defaultScaleNumberOfSteps
-
-        List(RendererConstants.defaultScaleNumberOfSteps + 1) {
-            val scaleValue = chartConfiguration.scale.min + scaleStep * it
-            Label(
-                label = chartConfiguration.labelsFormatter(scaleValue),
-                screenPositionX = 0F,
-                screenPositionY = 0F
-            )
-        }
-    }
+    private lateinit var yLabels: List<Label>
 
     override fun preDraw(configuration: ChartConfiguration): Boolean {
 
@@ -67,6 +54,17 @@ class BarChartRenderer(
                         max = data.limits().second
                     )
                 )
+
+        xLabels = data.toLabels()
+        val scaleStep = chartConfiguration.scale.size / RendererConstants.defaultScaleNumberOfSteps
+        yLabels = List(RendererConstants.defaultScaleNumberOfSteps + 1) {
+            val scaleValue = chartConfiguration.scale.min + scaleStep * it
+            Label(
+                    label = chartConfiguration.labelsFormatter(scaleValue),
+                    screenPositionX = 0F,
+                    screenPositionY = 0F
+            )
+        }
 
         val longestChartLabelWidth =
             yLabels.maxValueBy {

--- a/williamchart/src/main/java/com/db/williamchart/renderer/HorizontalBarChartRenderer.kt
+++ b/williamchart/src/main/java/com/db/williamchart/renderer/HorizontalBarChartRenderer.kt
@@ -36,22 +36,9 @@ class HorizontalBarChartRenderer(
 
     private lateinit var chartConfiguration: BarChartConfiguration
 
-    private val xLabels: List<Label> by lazy {
-        val scaleStep = chartConfiguration.scale.size / RendererConstants.defaultScaleNumberOfSteps
+    private lateinit var xLabels: List<Label>
 
-        List(RendererConstants.defaultScaleNumberOfSteps + 1) {
-            val scaleValue = chartConfiguration.scale.min + scaleStep * it
-            Label(
-                label = chartConfiguration.labelsFormatter(scaleValue),
-                screenPositionX = 0F,
-                screenPositionY = 0F
-            )
-        }
-    }
-
-    private val yLabels by lazy {
-        data.toLabels()
-    }
+    private lateinit var yLabels: List<Label>
 
     override fun preDraw(configuration: ChartConfiguration): Boolean {
 
@@ -67,6 +54,17 @@ class HorizontalBarChartRenderer(
                         max = data.limits().second
                     )
                 )
+
+        val scaleStep = chartConfiguration.scale.size / RendererConstants.defaultScaleNumberOfSteps
+        xLabels = List(RendererConstants.defaultScaleNumberOfSteps + 1) {
+            val scaleValue = chartConfiguration.scale.min + scaleStep * it
+            Label(
+                    label = chartConfiguration.labelsFormatter(scaleValue),
+                    screenPositionX = 0F,
+                    screenPositionY = 0F
+            )
+        }
+        yLabels = data.toLabels()
 
         val yLongestChartLabelWidth =
             yLabels.maxValueBy {

--- a/williamchart/src/main/java/com/db/williamchart/renderer/LineChartRenderer.kt
+++ b/williamchart/src/main/java/com/db/williamchart/renderer/LineChartRenderer.kt
@@ -34,22 +34,9 @@ class LineChartRenderer(
 
     private lateinit var chartConfiguration: LineChartConfiguration
 
-    private val xLabels: List<Label> by lazy {
-        data.toLabels()
-    }
+    private lateinit var xLabels: List<Label>
 
-    private val yLabels by lazy {
-        val scaleStep = chartConfiguration.scale.size / RendererConstants.defaultScaleNumberOfSteps
-
-        List(RendererConstants.defaultScaleNumberOfSteps + 1) {
-            val scaleValue = chartConfiguration.scale.min + scaleStep * it
-            Label(
-                label = chartConfiguration.labelsFormatter(scaleValue),
-                screenPositionX = 0F,
-                screenPositionY = 0F
-            )
-        }
-    }
+    private lateinit var yLabels: List<Label>
 
     override fun preDraw(configuration: ChartConfiguration): Boolean {
 
@@ -59,6 +46,17 @@ class LineChartRenderer(
 
         if (chartConfiguration.scale.notInitialized())
             chartConfiguration = chartConfiguration.copy(scale = data.toScale())
+
+        xLabels = data.toLabels()
+        val scaleStep = chartConfiguration.scale.size / RendererConstants.defaultScaleNumberOfSteps
+        yLabels = List(RendererConstants.defaultScaleNumberOfSteps + 1) {
+            val scaleValue = chartConfiguration.scale.min + scaleStep * it
+            Label(
+                    label = chartConfiguration.labelsFormatter(scaleValue),
+                    screenPositionX = 0F,
+                    screenPositionY = 0F
+            )
+        }
 
         val longestChartLabelWidth =
             yLabels.maxValueBy {


### PR DESCRIPTION
Reference: [my comment in #253](https://github.com/diogobernardino/williamchart/issues/253#issuecomment-571149030)

I think it's a useful addition - my use-case was to redraw a chart when clicking on it with different data set. Unfortunately it wasn't fully possible before - `Renderer`classes had new data in `data` variables so chart was drawn correctly. Only x and y labels were not redrawn, so my commit fixes that.

I hope it will be useful and bug-free - I'm still kind of a programming newbie.
Chris