### PR TITLE
Fix the demo build.gradle, so it now correctly skips signingconfig where necessary

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -45,8 +45,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (validSigningConfig)
-                signingConfig signingConfigs.release
+            signingConfig validSigningConfig ? signingConfigs.release : debug.signingConfig
         }
     }
 }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,18 +1,21 @@
 plugins {
     id("com.android.application")
+    id("kotlin-android")
+    id("kotlin-android-extensions")
     id("com.github.triplet.play") version "2.0.0"
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'com.github.triplet.play'
-
 Properties properties = new Properties()
 File localPropertiesFiles = project.rootProject.file('local.properties')
-
 if (localPropertiesFiles.exists())
     properties.load(localPropertiesFiles.newDataInputStream())
+
+def storeFileProperty = properties.getProperty("storeFile")
+def storePasswordProperty = properties.getProperty("storePassword")
+def keyAliasProperty = properties.getProperty("keyAlias")
+def keyPasswordProperty = properties.getProperty("keyPassword")
+
+def validSigningConfig = storeFileProperty && storePasswordProperty && keyAliasProperty && keyPasswordProperty
 
 android {
 
@@ -27,13 +30,13 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    if (localPropertiesFiles.exists()) {
+    if (validSigningConfig) {
         signingConfigs {
             release {
-                storeFile file(properties.getProperty("storeFile"))
-                storePassword properties.getProperty("storePassword")
-                keyAlias properties.getProperty("keyAlias")
-                keyPassword properties.getProperty("keyPassword")
+                storeFile file(storeFileProperty)
+                storePassword storePasswordProperty
+                keyAlias keyAliasProperty
+                keyPassword keyPasswordProperty
             }
         }
     }
@@ -42,7 +45,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (localPropertiesFiles.exists())
+            if (validSigningConfig)
                 signingConfig signingConfigs.release
         }
     }


### PR DESCRIPTION
mobile/build.gradle provides a signingConfig for release builds. The data for the signingConfig was loaded from `local.properties`, if it existed, otherwise the signingConfig was skipped. The problem is that Android Studio auto-creates a `local.properties`, so the file always exists when gradle runs - even if you manually delete it.

The local.properties `exists` check is therefore useless, and results in failed builds when checking out the project locally, or running on Jitpack: `Cause: path may not be null or empty string. path=''`

This PR removes the useless `exists` check and replaces it with a check that all the necessary properties are present (non-null) before passing them to signingConfig.

I also cleaned up some duplicated plugin declarations.